### PR TITLE
Ros2 roboteq config update

### DIFF
--- a/mammoth_snowplow/config/roboteq/roboteq.yaml
+++ b/mammoth_snowplow/config/roboteq/roboteq.yaml
@@ -1,6 +1,6 @@
 isc_roboteq:
   ros__parameters:
     Max_Current: 30.0
-    USB_Port: '/dev/ttyUSB1'
+    USB_Port: ' '
     Baudrate: 9600
     ChunkSize: 64 

--- a/mammoth_snowplow/config/roboteq/roboteq.yaml
+++ b/mammoth_snowplow/config/roboteq/roboteq.yaml
@@ -1,6 +1,5 @@
 isc_roboteq:
   ros__parameters:
     Max_Current: 30.0
-    USB_Port: ' '
     Baudrate: 9600
     ChunkSize: 64 


### PR DESCRIPTION
# Description
During early stages of testing, the roboteq opening the port was static meaning that `/dev/ttyUSB0` or `/dev/ttyUSB1` was hard coded into the configuration file. This posed an issue because the linux driver randomly opened a USB port when the roboteq was connected so it was hard to pin point which it was going to open. To get around that, the roboteq node now searches for the roboteq port on start up so the ros parameter in the roboteq config file is not needed now.

Fixes # (issue)
#54 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This has been tested on the physical robot to confirm that after removing the ros parameter  `USB_port` the system still functions as it should.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
