### PR TITLE
Add python autoformatting to actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,40 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+
+  # Auto formats the python code to avoid linter errors. 
+  autoflake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x' 
+          architecture: 'x64' 
+      - name: Auto format python
+        continue-on-error: true # This will err on success, as this is useful on the CLI. Just ignore it here
+        run: |
+          python -m pip install --upgrade pip
+          pip install autoflake8
+          autoflake8 -v -r --in-place --remove-unused-variables .
+      # Push using the actions bot if files were changed. 
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+      - name: Push changes
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'github-actions' 
+          git config --global user.email 'github-actions@github.com' 
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Automated autoflake8 formatting"
+          git push
+ 
+
+  # test ros. 
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/mammoth_gazebo/launch/include/gazebo/gazebo.launch.py
+++ b/mammoth_gazebo/launch/include/gazebo/gazebo.launch.py
@@ -25,10 +25,8 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
 
@@ -43,7 +41,8 @@ def generate_robot_model(pkg_description):
 
 def generate_launch_description():
     # ROS packages
-    pkg_mammoth_description = get_package_share_directory('mammoth_description')
+    pkg_mammoth_description = get_package_share_directory(
+        'mammoth_description')
     pkg_mammoth_gazebo = get_package_share_directory('mammoth_gazebo')
     pkg_ros_ign_gazebo = get_package_share_directory('ros_ign_gazebo')
 
@@ -53,8 +52,8 @@ def generate_launch_description():
     # Nodes
     ign_gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_ros_ign_gazebo, 'launch', 'ign_gazebo.launch.py')
-        ),
+            os.path.join(pkg_ros_ign_gazebo, 'launch',
+                         'ign_gazebo.launch.py')),
         launch_arguments={
             'ign_args': '-r ' + pkg_mammoth_gazebo + '/worlds/test.sdf'
         }.items(),
@@ -63,14 +62,16 @@ def generate_launch_description():
     ign_bridge = Node(
         package='ros_ign_bridge',
         executable='parameter_bridge',
-        arguments=['/world/test/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock',
-                   '/model/mammoth/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V',
-                   '/model/mammoth/cmd_vel@geometry_msgs/msg/Twist]ignition.msgs.Twist',
-                   '/model/mammoth/odometry@nav_msgs/msg/Odometry[ignition.msgs.Odometry',
-                   '/model/mammoth/joint_state@sensor_msgs/msg/JointState[ignition.msgs.Model',
-                   '/lidar@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan',
-                   '/lidar/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked',
-                   '/imu@sensor_msgs/msg/Imu[ignition.msgs.IMU'],
+        arguments=[
+            '/world/test/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock',
+            '/model/mammoth/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V',
+            '/model/mammoth/cmd_vel@geometry_msgs/msg/Twist]ignition.msgs.Twist',
+            '/model/mammoth/odometry@nav_msgs/msg/Odometry[ignition.msgs.Odometry',
+            '/model/mammoth/joint_state@sensor_msgs/msg/JointState[ignition.msgs.Model',
+            '/lidar@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan',
+            '/lidar/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked',
+            '/imu@sensor_msgs/msg/Imu[ignition.msgs.IMU'
+        ],
         output='screen',
         remappings=[
             ('/world/test/clock', '/clock'),
@@ -81,21 +82,15 @@ def generate_launch_description():
             ('/lidar', '/mammoth/raw_scan'),
             ('/lidar/points', '/mammoth/raw_points'),
             ('/imu', '/mammoth/imu'),
-        ]
-    )
+        ])
 
-    ign_spawn_robot = Node(
-        package='ros_ign_gazebo',
-        executable='create',
-        arguments=[
-            '-name', 'mammoth',
-            '-x', '0',
-            '-z', '0',
-            '-Y', '0',
-            '-topic', 'robot_description'
-        ],
-        output='screen'
-    )
+    ign_spawn_robot = Node(package='ros_ign_gazebo',
+                           executable='create',
+                           arguments=[
+                               '-name', 'mammoth', '-x', '0', '-z', '0', '-Y',
+                               '0', '-topic', 'robot_description'
+                           ],
+                           output='screen')
 
     return LaunchDescription([
         # Nodes

--- a/mammoth_gazebo/launch/include/lidar_processor/lidar_processor.launch.py
+++ b/mammoth_gazebo/launch/include/lidar_processor/lidar_processor.launch.py
@@ -47,12 +47,12 @@ def generate_launch_description():
         ],
         parameters=[{
             'use_sim_time': use_sim_time
-        }]
-    )
+        }])
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='true',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='true',
                               description='Use simulation clock if true'),
 
         # Nodes

--- a/mammoth_gazebo/launch/include/navigation/nav2/nav.launch.py
+++ b/mammoth_gazebo/launch/include/navigation/nav2/nav.launch.py
@@ -32,107 +32,95 @@ def generate_launch_description():
     autostart = LaunchConfiguration('autostart')
     params_file = LaunchConfiguration('config')
     default_bt_xml_filename = LaunchConfiguration('default_bt_xml_filename')
-    map_subscribe_transient_local = LaunchConfiguration('map_subscribe_transient_local')
+    map_subscribe_transient_local = LaunchConfiguration(
+        'map_subscribe_transient_local')
 
-    lifecycle_nodes = ['controller_server',
-                       'planner_server',
-                       'recoveries_server',
-                       'bt_navigator',
-                       'waypoint_follower']
+    lifecycle_nodes = [
+        'controller_server', 'planner_server', 'recoveries_server',
+        'bt_navigator', 'waypoint_follower'
+    ]
 
-    remappings = [('/tf', 'tf'),
-                  ('/tf_static', 'tf_static')]
+    remappings = [('/tf', 'tf'), ('/tf_static', 'tf_static')]
 
     param_substitutions = {
         'use_sim_time': use_sim_time,
         'default_bt_xml_filename': default_bt_xml_filename,
         'autostart': autostart,
-        'map_subscribe_transient_local': map_subscribe_transient_local}
+        'map_subscribe_transient_local': map_subscribe_transient_local
+    }
 
-    configured_params = RewrittenYaml(
-            source_file=params_file,
-            root_key=namespace,
-            param_rewrites=param_substitutions,
-            convert_types=True)
+    configured_params = RewrittenYaml(source_file=params_file,
+                                      root_key=namespace,
+                                      param_rewrites=param_substitutions,
+                                      convert_types=True)
 
     return LaunchDescription([
         # Set env var to print messages to stdout immediately
         SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '1'),
-
+        DeclareLaunchArgument('namespace',
+                              default_value='',
+                              description='Top-level namespace'),
         DeclareLaunchArgument(
-            'namespace', default_value='',
-            description='Top-level namespace'),
-
-        DeclareLaunchArgument(
-            'use_sim_time', default_value='false',
+            'use_sim_time',
+            default_value='false',
             description='Use simulation (Gazebo) clock if true'),
-
         DeclareLaunchArgument(
-            'autostart', default_value='true',
+            'autostart',
+            default_value='true',
             description='Automatically startup the nav2 stack'),
-
         DeclareLaunchArgument(
             'config',
-            default_value=os.path.join(bringup_dir, 'config/navigation', 'nav2_params.yaml'),
+            default_value=os.path.join(bringup_dir, 'config/navigation',
+                                       'nav2_params.yaml'),
             description='Full path to the ROS2 parameters file to use'),
-
         DeclareLaunchArgument(
             'default_bt_xml_filename',
             default_value=os.path.join(
                 get_package_share_directory('nav2_bt_navigator'),
                 'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
             description='Full path to the behavior tree xml file to use'),
-
         DeclareLaunchArgument(
-            'map_subscribe_transient_local', default_value='false',
+            'map_subscribe_transient_local',
+            default_value='false',
             description='Whether to set the map subscriber QoS to transient local'),
-
-        Node(
-            package='nav2_controller',
-            executable='controller_server',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_planner',
-            executable='planner_server',
-            name='planner_server',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_recoveries',
-            executable='recoveries_server',
-            name='recoveries_server',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_bt_navigator',
-            executable='bt_navigator',
-            name='bt_navigator',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_waypoint_follower',
-            executable='waypoint_follower',
-            name='waypoint_follower',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_lifecycle_manager',
-            executable='lifecycle_manager',
-            name='lifecycle_manager_navigation',
-            output='screen',
-            parameters=[{'use_sim_time': use_sim_time},
-                        {'autostart': autostart},
-                        {'node_names': lifecycle_nodes}]),
-
+        Node(package='nav2_controller',
+             executable='controller_server',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_planner',
+             executable='planner_server',
+             name='planner_server',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_recoveries',
+             executable='recoveries_server',
+             name='recoveries_server',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_bt_navigator',
+             executable='bt_navigator',
+             name='bt_navigator',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_waypoint_follower',
+             executable='waypoint_follower',
+             name='waypoint_follower',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_lifecycle_manager',
+             executable='lifecycle_manager',
+             name='lifecycle_manager_navigation',
+             output='screen',
+             parameters=[{
+                 'use_sim_time': use_sim_time
+             }, {
+                 'autostart': autostart
+             }, {
+                 'node_names': lifecycle_nodes
+             }]),
     ])

--- a/mammoth_gazebo/launch/include/navigation/navigation.launch.py
+++ b/mammoth_gazebo/launch/include/navigation/navigation.launch.py
@@ -38,19 +38,22 @@ def generate_launch_description():
 
     # Arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    slam_params_file_path = os.path.join(
-        pkg_mammoth_gazebo, 'config/slam', 'mapper_params_online_async.yaml')
-    slam_params_file = LaunchConfiguration('slam_params_file', default=slam_params_file_path)
+    slam_params_file_path = os.path.join(pkg_mammoth_gazebo, 'config/slam',
+                                         'mapper_params_online_async.yaml')
+    slam_params_file = LaunchConfiguration('slam_params_file',
+                                           default=slam_params_file_path)
 
-    nav2_params_file_path = os.path.join(
-        pkg_mammoth_gazebo, 'config/navigation', 'nav2_params.yaml')
-    nav2_params_file = LaunchConfiguration('nav2_params_file', default=nav2_params_file_path)
+    nav2_params_file_path = os.path.join(pkg_mammoth_gazebo,
+                                         'config/navigation',
+                                         'nav2_params.yaml')
+    nav2_params_file = LaunchConfiguration('nav2_params_file',
+                                           default=nav2_params_file_path)
 
     # Nodes
     slam_toolbox = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_slam_toolbox, 'launch', 'online_async_launch.py')
-        ),
+            os.path.join(pkg_slam_toolbox, 'launch',
+                         'online_async_launch.py')),
         launch_arguments={
             'namespace': '',
             'use_sim_time': use_sim_time,
@@ -60,27 +63,29 @@ def generate_launch_description():
 
     nav2_stack = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_mammoth_gazebo, 'launch/include/navigation/nav2', 'nav.launch.py')
-        ),
+            os.path.join(pkg_mammoth_gazebo, 'launch/include/navigation/nav2',
+                         'nav.launch.py')),
         launch_arguments={
             'namespace': '',
             'use_sim_time': use_sim_time,
-            'params_file':  nav2_params_file,
+            'params_file': nav2_params_file,
             'autostart': 'true'
         }.items(),
     )
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('slam_params_file', default_value=slam_params_file_path,
-                              description='The file path of the params file for slam ToolBox'),
-
-        DeclareLaunchArgument('nav2_params_file', default_value=nav2_params_file_path,
-                              description='The file path of the params file for Navigation2'),
-
-        DeclareLaunchArgument('use_sim_time', default_value='true',
+        DeclareLaunchArgument(
+            'slam_params_file',
+            default_value=slam_params_file_path,
+            description='The file path of the params file for slam ToolBox'),
+        DeclareLaunchArgument(
+            'nav2_params_file',
+            default_value=nav2_params_file_path,
+            description='The file path of the params file for Navigation2'),
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='true',
                               description='Use simulation clock if true'),
-
         slam_toolbox,
         nav2_stack,
     ])

--- a/mammoth_gazebo/launch/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py
+++ b/mammoth_gazebo/launch/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py
@@ -36,29 +36,29 @@ def generate_launch_description():
     pkg_mammoth_gazebo = get_package_share_directory('mammoth_gazebo')
 
     # Config
-    laserscan_config = os.path.join(
-        pkg_mammoth_gazebo, 'config/pointcloud_to_laserscan', 'pointcloud_to_laserscan.yaml')
+    laserscan_config = os.path.join(pkg_mammoth_gazebo,
+                                    'config/pointcloud_to_laserscan',
+                                    'pointcloud_to_laserscan.yaml')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
 
     # Nodes
-    pointcloud_to_laserscan = Node(
-        package='pointcloud_to_laserscan',
-        executable='pointcloud_to_laserscan_node',
-        remappings=[
-            ('cloud_in', '/mammoth/filtered_points'),
-            ('scan', '/scan')],
-        parameters=[{
-            'laserscan_config': laserscan_config,
-            'use_sim_time': use_sim_time,
-        }],
-        name='pointcloud_to_laserscan'
-    )
+    pointcloud_to_laserscan = Node(package='pointcloud_to_laserscan',
+                                   executable='pointcloud_to_laserscan_node',
+                                   remappings=[('cloud_in',
+                                                '/mammoth/filtered_points'),
+                                               ('scan', '/scan')],
+                                   parameters=[{
+                                       'laserscan_config': laserscan_config,
+                                       'use_sim_time': use_sim_time,
+                                   }],
+                                   name='pointcloud_to_laserscan')
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='true',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='true',
                               description='Use simulation time if true'),
         # Nodes
         pointcloud_to_laserscan,

--- a/mammoth_gazebo/launch/include/rviz/rviz.launch.py
+++ b/mammoth_gazebo/launch/include/rviz/rviz.launch.py
@@ -34,26 +34,30 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     # ROS packages
-    pkg_mammoth_description = get_package_share_directory('mammoth_description')
+    pkg_mammoth_description = get_package_share_directory(
+        'mammoth_description')
 
     # launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
     use_rviz = LaunchConfiguration('use_rviz', default='true')
 
     # Nodes
-    rviz = Node(
-        package='rviz2',
-        executable='rviz2',
-        arguments=['-d', os.path.join(pkg_mammoth_description, 'rviz', 'mammoth_gazebo.rviz')],
-        parameters=[{
-            'use_sim_time': use_sim_time
-        }],
-        condition=IfCondition(use_rviz)
-    )
+    rviz = Node(package='rviz2',
+                executable='rviz2',
+                arguments=[
+                    '-d',
+                    os.path.join(pkg_mammoth_description, 'rviz',
+                                 'mammoth_gazebo.rviz')
+                ],
+                parameters=[{
+                    'use_sim_time': use_sim_time
+                }],
+                condition=IfCondition(use_rviz))
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_rviz', default_value='false',
+        DeclareLaunchArgument('use_rviz',
+                              default_value='false',
                               description='Use simulation time if true'),
 
         # Node

--- a/mammoth_gazebo/launch/include/state_publishers/state_publishers.launch.py
+++ b/mammoth_gazebo/launch/include/state_publishers/state_publishers.launch.py
@@ -41,37 +41,35 @@ def generate_robot_model(pkg_description):
 
 def generate_launch_description():
     # ROS packages
-    pkg_mammoth_description = get_package_share_directory('mammoth_description')
+    pkg_mammoth_description = get_package_share_directory(
+        'mammoth_description')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
     robot_desc, urdf_file = generate_robot_model(pkg_mammoth_description)
 
     # Nodes
-    robot_state_publisher = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        name='robot_state_publisher',
-        output='screen',
-        parameters=[{
-            'use_sim_time': use_sim_time,
-            'robot_description': robot_desc,
-        }]
-    )
+    robot_state_publisher = Node(package='robot_state_publisher',
+                                 executable='robot_state_publisher',
+                                 name='robot_state_publisher',
+                                 output='screen',
+                                 parameters=[{
+                                     'use_sim_time': use_sim_time,
+                                     'robot_description': robot_desc,
+                                 }])
 
-    joint_state_publisher = Node(
-        package='joint_state_publisher',
-        executable='joint_state_publisher',
-        name='joint_state_publisher',
-        output='screen',
-        parameters=[{
-            'use_sim_time': use_sim_time
-        }]
-    )
+    joint_state_publisher = Node(package='joint_state_publisher',
+                                 executable='joint_state_publisher',
+                                 name='joint_state_publisher',
+                                 output='screen',
+                                 parameters=[{
+                                     'use_sim_time': use_sim_time
+                                 }])
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='true',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='true',
                               description='Use simulation clock if true'),
 
         # Nodes

--- a/mammoth_gazebo/launch/include/velocity_inverter/velocity_inverter.launch.py
+++ b/mammoth_gazebo/launch/include/velocity_inverter/velocity_inverter.launch.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
@@ -33,19 +32,18 @@ def generate_launch_description():
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
 
-    velocity_inverter = Node(
-        package='vel_processor',
-        executable='vel_processor',
-        name='vel_processor',
-        output='screen',
-        parameters=[{
-            'use_sim_time': use_sim_time
-        }]
-    )
+    velocity_inverter = Node(package='vel_processor',
+                             executable='vel_processor',
+                             name='vel_processor',
+                             output='screen',
+                             parameters=[{
+                                 'use_sim_time': use_sim_time
+                             }])
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='true',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='true',
                               description='Use simulation clock if true'),
 
         # Nodes

--- a/mammoth_gazebo/launch/include/waypoint_publisher/waypoint.launch.py
+++ b/mammoth_gazebo/launch/include/waypoint_publisher/waypoint.launch.py
@@ -1,4 +1,3 @@
-
 # MIT License
 #
 # Copyright (c) 2021 Intelligent Systems Club
@@ -38,29 +37,31 @@ def generate_launch_description():
     pkg_mammoth_gazebo = get_package_share_directory('mammoth_gazebo')
 
     # Config
-    waypoints = os.path.join(pkg_mammoth_gazebo, 'config/waypoints', 'single-I.csv')
+    waypoints = os.path.join(pkg_mammoth_gazebo, 'config/waypoints',
+                             'single-I.csv')
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     follow_waypoints = LaunchConfiguration('follow_waypoints', default='true')
 
     # Nodes
-    waypoint_publisher = Node(
-        package='waypoint',
-        executable='waypoint',
-        name='waypoint',
-        output='screen',
-	    parameters=[
-            {'filename': waypoints},
-            {'use_sim_time': use_sim_time}
-        ],
-	    condition=IfCondition(follow_waypoints)
-    )
+    waypoint_publisher = Node(package='waypoint',
+                              executable='waypoint',
+                              name='waypoint',
+                              output='screen',
+                              parameters=[{
+                                  'filename': waypoints
+                              }, {
+                                  'use_sim_time': use_sim_time
+                              }],
+                              condition=IfCondition(follow_waypoints))
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='false',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='false',
                               description='Use simulation time if true'),
-        DeclareLaunchArgument('follow_waypoints', default_value='true',
+        DeclareLaunchArgument('follow_waypoints',
+                              default_value='true',
                               description='Follow waypoints if true'),
         # Nodes
         waypoint_publisher,

--- a/mammoth_gazebo/launch/mammoth.launch.py
+++ b/mammoth_gazebo/launch/mammoth.launch.py
@@ -37,7 +37,8 @@ def generate_launch_description():
     pkg_teleop_twist_joy = get_package_share_directory('teleop_twist_joy')
 
     # Config
-    joy_config = os.path.join(pkg_mammoth_gazebo, 'config/joystick', 'xbone.config.yaml')
+    joy_config = os.path.join(pkg_mammoth_gazebo, 'config/joystick',
+                              'xbone.config.yaml')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
@@ -46,104 +47,94 @@ def generate_launch_description():
 
     # Nodes
     state_publishers = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-          pkg_mammoth_gazebo, 'launch'),
-          '/include/state_publishers/state_publishers.launch.py']
-        ),
-        launch_arguments={
-        	'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/state_publishers/state_publishers.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     ign_gazebo = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-        	pkg_mammoth_gazebo, 'launch'),
-          '/include/gazebo/gazebo.launch.py']
-        ),
-    )
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/gazebo/gazebo.launch.py'
+        ]), )
 
     joy_with_teleop_twist = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource(
-        os.path.join(pkg_teleop_twist_joy, 'launch', 'teleop-launch.py')
-      ),
-      launch_arguments={
-          'joy_config': 'xbox',
-          'joy_dev': '/dev/input/js0',
-          'config_filepath': joy_config
-      }.items(),
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_teleop_twist_joy, 'launch', 'teleop-launch.py')),
+        launch_arguments={
+            'joy_config': 'xbox',
+            'joy_dev': '/dev/input/js0',
+            'config_filepath': joy_config
+        }.items(),
     )
 
     velocity_inverter = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-          pkg_mammoth_gazebo, 'launch'),
-          '/include/velocity_inverter/velocity_inverter.launch.py']
-        ),
-        launch_arguments={
-          'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/velocity_inverter/velocity_inverter.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     lidar_processor = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-        pkg_mammoth_gazebo, 'launch'),
-        	'/include/lidar_processor/lidar_processor.launch.py']
-				),
-        launch_arguments={
-        	'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/lidar_processor/lidar_processor.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     pointcloud_to_laserscan = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-        pkg_mammoth_gazebo, 'launch'),
-        	'/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py']
-				),
-        launch_arguments={
-        	'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     navigation = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-        pkg_mammoth_gazebo, 'launch'),
-        	'/include/navigation/navigation.launch.py']
-				),
-        launch_arguments={
-          'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/navigation/navigation.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     rviz = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-        pkg_mammoth_gazebo, 'launch'),
-        '/include/rviz/rviz.launch.py']
-			),
-      launch_arguments={
-        'use_rviz': use_rviz,
-        'use_sim_time': use_sim_time
-      }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/rviz/rviz.launch.py'
+        ]),
+        launch_arguments={
+            'use_rviz': use_rviz,
+            'use_sim_time': use_sim_time
+        }.items(),
     )
 
     waypoint_publisher = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-          pkg_mammoth_gazebo, 'launch'),
-          '/include/waypoint_publisher/waypoint.launch.py']
-        ),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_gazebo, 'launch'),
+            '/include/waypoint_publisher/waypoint.launch.py'
+        ]),
         launch_arguments={
-        	'use_sim_time': use_sim_time,
-        	'follow_waypoints': follow_waypoints
+            'use_sim_time': use_sim_time,
+            'follow_waypoints': follow_waypoints
         }.items(),
     )
-    
+
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='true',
-                              description='Use simulation (Gazebo) clock if true'),
-
-        DeclareLaunchArgument('use_rviz', default_value='true',
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='true',
+            description='Use simulation (Gazebo) clock if true'),
+        DeclareLaunchArgument('use_rviz',
+                              default_value='true',
                               description='Open rviz if true'),
-                              
-        DeclareLaunchArgument('follow_waypoints', default_value='false',
+        DeclareLaunchArgument('follow_waypoints',
+                              default_value='false',
                               description='follow way points if true'),
 
         # Nodes
@@ -151,7 +142,6 @@ def generate_launch_description():
         ign_gazebo,
         joy_with_teleop_twist,
         velocity_inverter,
-
         lidar_processor,
         pointcloud_to_laserscan,
         navigation,

--- a/mammoth_gazebo/launch/test/joystick_teleop.launch.py
+++ b/mammoth_gazebo/launch/test/joystick_teleop.launch.py
@@ -31,27 +31,32 @@ import launch_ros.actions
 def generate_launch_description():
     joy_config = launch.substitutions.LaunchConfiguration('joy_config')
     joy_dev = launch.substitutions.LaunchConfiguration('joy_dev')
-    config_filepath = launch.substitutions.LaunchConfiguration('config_filepath')
+    config_filepath = launch.substitutions.LaunchConfiguration(
+        'config_filepath')
 
     return launch.LaunchDescription([
-        launch.actions.DeclareLaunchArgument('joy_config', default_value='ps3'),
-        launch.actions.DeclareLaunchArgument('joy_dev', default_value='/dev/input/js0'),
-        launch.actions.DeclareLaunchArgument('config_filepath', default_value=[
+        launch.actions.DeclareLaunchArgument('joy_config',
+                                             default_value='ps3'),
+        launch.actions.DeclareLaunchArgument('joy_dev',
+                                             default_value='/dev/input/js0'),
+        launch.actions.DeclareLaunchArgument(
+            'config_filepath',
+            default_value=[
                 launch.substitutions.TextSubstitution(text=os.path.join(
-                    get_package_share_directory('teleop_twist_joy'), 'config', '')
-                ),
-                joy_config, launch.substitutions.TextSubstitution(text='.config.yaml')
-            ]
-        ),
-
-        launch_ros.actions.Node(
-            package='joy', executable='joy_node', name='joy_node',
-            parameters=[{
-                'dev': joy_dev,
-                'deadzone': 0.3,
-                'autorepeat_rate': 20.0,
-            }]),
-        launch_ros.actions.Node(
-            package='teleop_twist_joy', executable='teleop_node',
-            name='teleop_twist_joy_node', parameters=[config_filepath]),
+                    get_package_share_directory('teleop_twist_joy'), 'config',
+                    '')), joy_config,
+                launch.substitutions.TextSubstitution(text='.config.yaml')
+            ]),
+        launch_ros.actions.Node(package='joy',
+                                executable='joy_node',
+                                name='joy_node',
+                                parameters=[{
+                                    'dev': joy_dev,
+                                    'deadzone': 0.3,
+                                    'autorepeat_rate': 20.0,
+                                }]),
+        launch_ros.actions.Node(package='teleop_twist_joy',
+                                executable='teleop_node',
+                                name='teleop_twist_joy_node',
+                                parameters=[config_filepath]),
     ])

--- a/mammoth_snowplow/launch/include/lidar_processor/lidar_processor.launch.py
+++ b/mammoth_snowplow/launch/include/lidar_processor/lidar_processor.launch.py
@@ -20,22 +20,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
 
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     # ROS packages
-    pkg_mammoth_gazebo = get_package_share_directory('mammoth_snowplow')
+    get_package_share_directory('mammoth_snowplow')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
@@ -55,12 +52,12 @@ def generate_launch_description():
         ],
         parameters=[{
             'use_sim_time': use_sim_time
-        }]
-    )
+        }])
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='false',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='false',
                               description='Use simulation clock if true'),
 
         # Nodes

--- a/mammoth_snowplow/launch/include/navigation/nav2/nav.launch.py
+++ b/mammoth_snowplow/launch/include/navigation/nav2/nav.launch.py
@@ -32,107 +32,96 @@ def generate_launch_description():
     autostart = LaunchConfiguration('autostart')
     params_file = LaunchConfiguration('config')
     default_bt_xml_filename = LaunchConfiguration('default_bt_xml_filename')
-    map_subscribe_transient_local = LaunchConfiguration('map_subscribe_transient_local')
-    
-    lifecycle_nodes = ['controller_server',
-                       'planner_server',
-                       'recoveries_server',
-                       'bt_navigator',
-                       'waypoint_follower']
+    map_subscribe_transient_local = LaunchConfiguration(
+        'map_subscribe_transient_local')
 
-    remappings = [('/tf', 'tf'),
-                  ('/tf_static', 'tf_static')]
+    lifecycle_nodes = [
+        'controller_server', 'planner_server', 'recoveries_server',
+        'bt_navigator', 'waypoint_follower'
+    ]
+
+    remappings = [('/tf', 'tf'), ('/tf_static', 'tf_static')]
 
     param_substitutions = {
         'use_sim_time': use_sim_time,
         'default_bt_xml_filename': default_bt_xml_filename,
         'autostart': autostart,
-        'map_subscribe_transient_local': map_subscribe_transient_local}
+        'map_subscribe_transient_local': map_subscribe_transient_local
+    }
 
-    configured_params = RewrittenYaml(
-            source_file=params_file,
-            root_key=namespace,
-            param_rewrites=param_substitutions,
-            convert_types=True)
+    configured_params = RewrittenYaml(source_file=params_file,
+                                      root_key=namespace,
+                                      param_rewrites=param_substitutions,
+                                      convert_types=True)
 
     return LaunchDescription([
         # Set env var to print messages to stdout immediately
         SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '1'),
-
+        DeclareLaunchArgument('namespace',
+                              default_value='',
+                              description='Top-level namespace'),
         DeclareLaunchArgument(
-            'namespace', default_value='',
-            description='Top-level namespace'),
-
-        DeclareLaunchArgument(
-            'use_sim_time', default_value='false',
+            'use_sim_time',
+            default_value='false',
             description='Use simulation (Gazebo) clock if true'),
-
         DeclareLaunchArgument(
-            'autostart', default_value='true',
+            'autostart',
+            default_value='true',
             description='Automatically startup the nav2 stack'),
-
         DeclareLaunchArgument(
             'config',
-            default_value=os.path.join(bringup_dir, 'config/navigation', 'nav2_params.yaml'),
+            default_value=os.path.join(bringup_dir, 'config/navigation',
+                                       'nav2_params.yaml'),
             description='Full path to the ROS2 parameters file to use'),
-
         DeclareLaunchArgument(
             'default_bt_xml_filename',
             default_value=os.path.join(
                 get_package_share_directory('nav2_bt_navigator'),
                 'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
             description='Full path to the behavior tree xml file to use'),
-
         DeclareLaunchArgument(
-            'map_subscribe_transient_local', default_value='false',
-            description='Whether to set the map subscriber QoS to transient local'),
-
-        Node(
-            package='nav2_controller',
-            executable='controller_server',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_planner',
-            executable='planner_server',
-            name='planner_server',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_recoveries',
-            executable='recoveries_server',
-            name='recoveries_server',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_bt_navigator',
-            executable='bt_navigator',
-            name='bt_navigator',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-
-        Node(
-            package='nav2_waypoint_follower',
-            executable='waypoint_follower',
-            name='waypoint_follower',
-            output='screen',
-            parameters=[configured_params],
-            remappings=remappings),
-            
-        Node(
-            package='nav2_lifecycle_manager',
-            executable='lifecycle_manager',
-            name='lifecycle_manager_navigation',
-            output='screen',
-            parameters=[{'use_sim_time': use_sim_time},
-                        {'autostart': autostart},
-                        {'node_names': lifecycle_nodes}]),
-
+            'map_subscribe_transient_local',
+            default_value='false',
+            description=
+            'Whether to set the map subscriber QoS to transient local'),
+        Node(package='nav2_controller',
+             executable='controller_server',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_planner',
+             executable='planner_server',
+             name='planner_server',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_recoveries',
+             executable='recoveries_server',
+             name='recoveries_server',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_bt_navigator',
+             executable='bt_navigator',
+             name='bt_navigator',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_waypoint_follower',
+             executable='waypoint_follower',
+             name='waypoint_follower',
+             output='screen',
+             parameters=[configured_params],
+             remappings=remappings),
+        Node(package='nav2_lifecycle_manager',
+             executable='lifecycle_manager',
+             name='lifecycle_manager_navigation',
+             output='screen',
+             parameters=[{
+                 'use_sim_time': use_sim_time
+             }, {
+                 'autostart': autostart
+             }, {
+                 'node_names': lifecycle_nodes
+             }]),
     ])

--- a/mammoth_snowplow/launch/include/navigation/navigation.launch.py
+++ b/mammoth_snowplow/launch/include/navigation/navigation.launch.py
@@ -38,18 +38,22 @@ def generate_launch_description():
 
     # Arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
-    slam_params_file_path = os.path.join(
-        pkg_mammoth_snowplow, 'config/slam', 'mapper_params_online_async.yaml')
-    slam_params_file = LaunchConfiguration('slam_params_file', default=slam_params_file_path)
+    slam_params_file_path = os.path.join(pkg_mammoth_snowplow, 'config/slam',
+                                         'mapper_params_online_async.yaml')
+    slam_params_file = LaunchConfiguration('slam_params_file',
+                                           default=slam_params_file_path)
 
-    nav2_params_file_path = os.path.join(pkg_mammoth_snowplow, 'config/navigation', 'nav2_params.yaml')
-    nav2_params_file = LaunchConfiguration('nav2_params_file', default=nav2_params_file_path)
+    nav2_params_file_path = os.path.join(pkg_mammoth_snowplow,
+                                         'config/navigation',
+                                         'nav2_params.yaml')
+    nav2_params_file = LaunchConfiguration('nav2_params_file',
+                                           default=nav2_params_file_path)
 
     # Nodes
     slam_toolbox = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_slam_toolbox, 'launch', 'online_async_launch.py')
-        ),
+            os.path.join(pkg_slam_toolbox, 'launch',
+                         'online_async_launch.py')),
         launch_arguments={
             'namespace': '',
             'use_sim_time': use_sim_time,
@@ -59,29 +63,28 @@ def generate_launch_description():
 
     nav2_stack = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_mammoth_snowplow, 'launch/include/navigation/nav2', 'nav.launch.py')
-        ),
+            os.path.join(pkg_mammoth_snowplow,
+                         'launch/include/navigation/nav2', 'nav.launch.py')),
         launch_arguments={
             'namespace': '',
             'use_sim_time': use_sim_time,
-            'params_file':  nav2_params_file,
+            'params_file': nav2_params_file,
             'autostart': 'true'
         }.items(),
     )
 
     return LaunchDescription([
-
-        DeclareLaunchArgument('slam_params_file', default_value=slam_params_file_path,
-                              description='The file path of the params file for slam ToolBox'),
-
-        DeclareLaunchArgument('nav2_params_file', default_value=nav2_params_file_path,
-                              description='The file path of the params file for Navigation2'),
-
         DeclareLaunchArgument(
-            'use_sim_time', default_value='true',
-            description='Use simulation clock if true'),
-
-	 slam_toolbox,
-	 nav2_stack,
-
+            'slam_params_file',
+            default_value=slam_params_file_path,
+            description='The file path of the params file for slam ToolBox'),
+        DeclareLaunchArgument(
+            'nav2_params_file',
+            default_value=nav2_params_file_path,
+            description='The file path of the params file for Navigation2'),
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='true',
+                              description='Use simulation clock if true'),
+        slam_toolbox,
+        nav2_stack,
     ])

--- a/mammoth_snowplow/launch/include/ouster_os1/os1.launch.py
+++ b/mammoth_snowplow/launch/include/ouster_os1/os1.launch.py
@@ -37,54 +37,52 @@ def generate_launch_description():
     parameter_file = LaunchConfiguration('config')
     node_name = 'ouster_driver'
 
-    params_declare = DeclareLaunchArgument('config',
-                                           default_value=os.path.join(
-                                               share_dir, 'config/sensors/lidar', 'os1.yaml'),
-                                           description='FPath to the ROS2 parameters file to use.')
+    params_declare = DeclareLaunchArgument(
+        'config',
+        default_value=os.path.join(share_dir, 'config/sensors/lidar',
+                                   'os1.yaml'),
+        description='FPath to the ROS2 parameters file to use.')
 
-    driver_node = LifecycleNode(package='ros2_ouster',
-                                executable='ouster_driver',
-                                name=node_name,
-                                output='screen',
-                                emulate_tty=True,
-                                parameters=[parameter_file],
-                                namespace='/',
-                                )
-
-    configure_event = EmitEvent(
-        event=ChangeState(
-            lifecycle_node_matcher=matches_action(driver_node),
-            transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
-        )
+    driver_node = LifecycleNode(
+        package='ros2_ouster',
+        executable='ouster_driver',
+        name=node_name,
+        output='screen',
+        emulate_tty=True,
+        parameters=[parameter_file],
+        namespace='/',
     )
+
+    configure_event = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=matches_action(driver_node),
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+    ))
 
     activate_event = RegisterEventHandler(
         OnStateTransition(
-            target_lifecycle_node=driver_node, goal_state='inactive',
+            target_lifecycle_node=driver_node,
+            goal_state='inactive',
             entities=[
                 LogInfo(
                     msg="[LifecycleLaunch] Ouster driver node is activating."),
                 EmitEvent(event=ChangeState(
                     lifecycle_node_matcher=matches_action(driver_node),
-                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
+                    transition_id=lifecycle_msgs.msg.Transition.
+                    TRANSITION_ACTIVATE,
                 )),
             ],
-        )
-    )
+        ))
 
     # TODO make lifecycle transition to shutdown before SIGINT
     shutdown_event = RegisterEventHandler(
-        OnShutdown(
-            on_shutdown=[
-                EmitEvent(event=ChangeState(
-                  lifecycle_node_matcher=matches_node_name(node_name=node_name),
-                  transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVE_SHUTDOWN,
-                )),
-                LogInfo(
-                    msg="[LifecycleLaunch] Ouster driver node is exiting."),
-            ],
-        )
-    )
+        OnShutdown(on_shutdown=[
+            EmitEvent(event=ChangeState(
+                lifecycle_node_matcher=matches_node_name(node_name=node_name),
+                transition_id=lifecycle_msgs.msg.Transition.
+                TRANSITION_ACTIVE_SHUTDOWN,
+            )),
+            LogInfo(msg="[LifecycleLaunch] Ouster driver node is exiting."),
+        ], ))
 
     return LaunchDescription([
         params_declare,

--- a/mammoth_snowplow/launch/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py
+++ b/mammoth_snowplow/launch/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py
@@ -26,37 +26,36 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
+
 
 def generate_launch_description():
     # ROS packages
     pkg_mammoth_snowplow = get_package_share_directory('mammoth_snowplow')
 
     # Config
-    laserscan_config = os.path.join(pkg_mammoth_snowplow, 'config/pointcloud_to_laserscan', 'pointcloud_to_laserscan.yaml')
+    laserscan_config = os.path.join(pkg_mammoth_snowplow,
+                                    'config/pointcloud_to_laserscan',
+                                    'pointcloud_to_laserscan.yaml')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
 
     # Nodes
-    pointcloud_to_laserscan = Node(
-        package='pointcloud_to_laserscan',
-        executable='pointcloud_to_laserscan_node',
-        remappings=[
-            ('cloud_in', '/mammoth/filtered_points'),
-            ('scan', '/scan')],
-        parameters=[laserscan_config],
-        name='pointcloud_to_laserscan'
-    )
+    pointcloud_to_laserscan = Node(package='pointcloud_to_laserscan',
+                                   executable='pointcloud_to_laserscan_node',
+                                   remappings=[('cloud_in',
+                                                '/mammoth/filtered_points'),
+                                               ('scan', '/scan')],
+                                   parameters=[laserscan_config],
+                                   name='pointcloud_to_laserscan')
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='false',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='false',
                               description='Use simulation time if true'),
         # Nodes
         pointcloud_to_laserscan,

--- a/mammoth_snowplow/launch/include/realsense/rs_launch.py
+++ b/mammoth_snowplow/launch/include/realsense/rs_launch.py
@@ -11,159 +11,462 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Launch realsense2_camera node."""
 import os
 from launch import LaunchDescription
-from ament_index_python.packages import get_package_share_directory
 import launch_ros.actions
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch.conditions import IfCondition
 
+configurable_parameters = [
+    {
+        'name': 'camera_name',
+        'default': 'camera',
+        'description': 'camera unique name'
+    },
+    {
+        'name': 'serial_no',
+        'default': "''",
+        'description': 'choose device by serial number'
+    },
+    {
+        'name': 'usb_port_id',
+        'default': "''",
+        'description': 'choose device by usb port id'
+    },
+    {
+        'name': 'device_type',
+        'default': "''",
+        'description': 'choose device by type'
+    },
+    {
+        'name': 'config_file',
+        'default': "''",
+        'description': 'yaml config file'
+    },
+    {
+        'name': 'enable_pointcloud',
+        'default': 'false',
+        'description': 'enable pointcloud'
+    },
+    {
+        'name': 'unite_imu_method',
+        'default': "''",
+        'description': '[copy|linear_interpolation]'
+    },
+    {
+        'name': 'json_file_path',
+        'default': "''",
+        'description': 'allows advanced configuration'
+    },
+    {
+        'name': 'log_level',
+        'default': 'info',
+        'description': 'debug log level [DEBUG|INFO|WARN|ERROR|FATAL]'
+    },
+    {
+        'name': 'output',
+        'default': 'screen',
+        'description': 'pipe node output [screen|log]'
+    },
+    {
+        'name': 'depth_width',
+        'default': '-1',
+        'description': 'depth image width'
+    },
+    {
+        'name': 'depth_height',
+        'default': '-1',
+        'description': 'depth image height'
+    },
+    {
+        'name': 'enable_depth',
+        'default': 'true',
+        'description': 'enable depth stream'
+    },
+    {
+        'name': 'color_width',
+        'default': '-1',
+        'description': 'color image width'
+    },
+    {
+        'name': 'color_height',
+        'default': '-1',
+        'description': 'color image height'
+    },
+    {
+        'name': 'enable_color',
+        'default': 'true',
+        'description': 'enable color stream'
+    },
+    {
+        'name': 'infra_width',
+        'default': '-1',
+        'description': 'infra width'
+    },
+    {
+        'name': 'infra_height',
+        'default': '-1',
+        'description': 'infra width'
+    },
+    {
+        'name': 'enable_infra1',
+        'default': 'true',
+        'description': 'enable infra1 stream'
+    },
+    {
+        'name': 'enable_infra2',
+        'default': 'true',
+        'description': 'enable infra2 stream'
+    },
+    {
+        'name': 'infra_rgb',
+        'default': 'false',
+        'description': 'enable infra2 stream'
+    },
+    {
+        'name': 'fisheye_width',
+        'default': '-1',
+        'description': 'fisheye width'
+    },
+    {
+        'name': 'fisheye_height',
+        'default': '-1',
+        'description': 'fisheye width'
+    },
+    {
+        'name': 'enable_fisheye1',
+        'default': 'true',
+        'description': 'enable fisheye1 stream'
+    },
+    {
+        'name': 'enable_fisheye2',
+        'default': 'true',
+        'description': 'enable fisheye2 stream'
+    },
+    {
+        'name': 'confidence_width',
+        'default': '-1',
+        'description': 'depth image width'
+    },
+    {
+        'name': 'confidence_height',
+        'default': '-1',
+        'description': 'depth image height'
+    },
+    {
+        'name': 'enable_confidence',
+        'default': 'true',
+        'description': 'enable depth stream'
+    },
+    {
+        'name': 'fisheye_fps',
+        'default': '-1.',
+        'description': ''
+    },
+    {
+        'name': 'depth_fps',
+        'default': '-1.',
+        'description': ''
+    },
+    {
+        'name': 'confidence_fps',
+        'default': '-1.',
+        'description': ''
+    },
+    {
+        'name': 'infra_fps',
+        'default': '-1.',
+        'description': ''
+    },
+    {
+        'name': 'color_fps',
+        'default': '-1.',
+        'description': ''
+    },
+    {
+        'name': 'gyro_fps',
+        'default': '-1.',
+        'description': ''
+    },
+    {
+        'name': 'accel_fps',
+        'default': '-1.',
+        'description': ''
+    },
+    {
+        'name': 'color_qos',
+        'default': 'SYSTEM_DEFAULT',
+        'description': 'QoS profile name'
+    },
+    {
+        'name': 'confidence_qos',
+        'default': 'SYSTEM_DEFAULT',
+        'description': 'QoS profile name'
+    },
+    {
+        'name': 'depth_qos',
+        'default': 'SYSTEM_DEFAULT',
+        'description': 'QoS profile name'
+    },
+    {
+        'name': 'fisheye_qos',
+        'default': 'SYSTEM_DEFAULT',
+        'description': 'QoS profile name'
+    },
+    {
+        'name': 'infra_qos',
+        'default': 'SYSTEM_DEFAULT',
+        'description': 'QoS profile name'
+    },
+    {
+        'name': 'pointcloud_qos',
+        'default': 'SYSTEM_DEFAULT',
+        'description': 'QoS profile name'
+    },
+    {
+        'name': 'enable_gyro',
+        'default': 'false',
+        'description': ''
+    },
+    {
+        'name': 'enable_accel',
+        'default': 'false',
+        'description': ''
+    },
+    {
+        'name': 'pointcloud_texture_stream',
+        'default': 'RS2_STREAM_COLOR',
+        'description': 'testure stream for pointcloud'
+    },
+    {
+        'name': 'pointcloud_texture_index',
+        'default': '0',
+        'description': 'testure stream index for pointcloud'
+    },
+    {
+        'name': 'enable_sync',
+        'default': 'false',
+        'description': ''
+    },
+    {
+        'name': 'align_depth',
+        'default': 'false',
+        'description': ''
+    },
+    {
+        'name': 'filters',
+        'default': "''",
+        'description': ''
+    },
+    {
+        'name': 'clip_distance',
+        'default': '-2.',
+        'description': ''
+    },
+    {
+        'name': 'linear_accel_cov',
+        'default': '0.01',
+        'description': ''
+    },
+    {
+        'name': 'initial_reset',
+        'default': 'false',
+        'description': ''
+    },
+    {
+        'name': 'allow_no_texture_points',
+        'default': 'false',
+        'description': ''
+    },
+    {
+        'name': 'ordered_pc',
+        'default': 'false',
+        'description': ''
+    },
+    {
+        'name': 'calib_odom_file',
+        'default': "''",
+        'description': "''"
+    },
+    {
+        'name': 'topic_odom_in',
+        'default': "''",
+        'description': 'topic for T265 wheel odometry'
+    },
+    {
+        'name': 'tf_publish_rate',
+        'default': '20.0',
+        'description': 'Rate of publishing static_tf'
+    },
+    {
+        'name': 'diagnostics_period',
+        'default': '0.0',
+        'description': 'Rate of publishing diagnostics. 0=Disabled'
+    },
+    {
+        'name': 'rosbag_filename',
+        'default': "''",
+        'description': 'A realsense bagfile to run from as a device'
+    },
+    {
+        'name': 'temporal.holes_fill',
+        'default': '0',
+        'description': 'Persistency mode'
+    },
+    {
+        'name': 'stereo_module.exposure.1',
+        'default': '7500',
+        'description': 'Initial value for hdr_merge filter'
+    },
+    {
+        'name': 'stereo_module.gain.1',
+        'default': '16',
+        'description': 'Initial value for hdr_merge filter'
+    },
+    {
+        'name': 'stereo_module.exposure.2',
+        'default': '1',
+        'description': 'Initial value for hdr_merge filter'
+    },
+    {
+        'name': 'stereo_module.gain.2',
+        'default': '16',
+        'description': 'Initial value for hdr_merge filter'
+    },
+    {
+        'name': 'wait_for_device_timeout',
+        'default': '-1.',
+        'description': 'Timeout for waiting for device to connect (Seconds)'
+    },
+    {
+        'name': 'reconnect_timeout',
+        'default': '6.',
+        'description':
+        'Timeout(seconds) between consequtive reconnection attempts'
+    },
+    {
+        'name': 'odom_frame_id',
+        'default': 'odom',
+        'description': 'set odom frame'
+    },
+    {
+        'name': 'pose_frame_id',
+        'default': 'base_footprint',
+        'description': 'set pose frame'
+    },
+    {
+        'name': 'publish_tf',
+        'default': 'true',
+        'description': 'publish tf'
+    },
+]
 
-configurable_parameters = [{'name': 'camera_name',                  'default': 'camera', 'description': 'camera unique name'},
-                           {'name': 'serial_no',                    'default': "''", 'description': 'choose device by serial number'},
-                           {'name': 'usb_port_id',                  'default': "''", 'description': 'choose device by usb port id'},
-                           {'name': 'device_type',                  'default': "''", 'description': 'choose device by type'},
-                           {'name': 'config_file',                  'default': "''", 'description': 'yaml config file'},
-                           {'name': 'enable_pointcloud',            'default': 'false', 'description': 'enable pointcloud'},
-                           {'name': 'unite_imu_method',             'default': "''", 'description': '[copy|linear_interpolation]'},
-                           {'name': 'json_file_path',               'default': "''", 'description': 'allows advanced configuration'},
-                           {'name': 'log_level',                    'default': 'info', 'description': 'debug log level [DEBUG|INFO|WARN|ERROR|FATAL]'},
-                           {'name': 'output',                       'default': 'screen', 'description': 'pipe node output [screen|log]'},
-                           {'name': 'depth_width',                  'default': '-1', 'description': 'depth image width'},
-                           {'name': 'depth_height',                 'default': '-1', 'description': 'depth image height'},
-                           {'name': 'enable_depth',                 'default': 'true', 'description': 'enable depth stream'},
-                           {'name': 'color_width',                  'default': '-1', 'description': 'color image width'},
-                           {'name': 'color_height',                 'default': '-1', 'description': 'color image height'},
-                           {'name': 'enable_color',                 'default': 'true', 'description': 'enable color stream'},
-                           {'name': 'infra_width',                  'default': '-1', 'description': 'infra width'},
-                           {'name': 'infra_height',                 'default': '-1', 'description': 'infra width'},
-                           {'name': 'enable_infra1',                'default': 'true', 'description': 'enable infra1 stream'},
-                           {'name': 'enable_infra2',                'default': 'true', 'description': 'enable infra2 stream'},
-                           {'name': 'infra_rgb',                    'default': 'false', 'description': 'enable infra2 stream'},
-                           {'name': 'fisheye_width',                'default': '-1', 'description': 'fisheye width'},
-                           {'name': 'fisheye_height',               'default': '-1', 'description': 'fisheye width'},
-                           {'name': 'enable_fisheye1',              'default': 'true', 'description': 'enable fisheye1 stream'},
-                           {'name': 'enable_fisheye2',              'default': 'true', 'description': 'enable fisheye2 stream'},
-                           {'name': 'confidence_width',             'default': '-1', 'description': 'depth image width'},
-                           {'name': 'confidence_height',            'default': '-1', 'description': 'depth image height'},
-                           {'name': 'enable_confidence',            'default': 'true', 'description': 'enable depth stream'},
-                           {'name': 'fisheye_fps',                  'default': '-1.', 'description': ''},
-                           {'name': 'depth_fps',                    'default': '-1.', 'description': ''},
-                           {'name': 'confidence_fps',               'default': '-1.', 'description': ''},
-                           {'name': 'infra_fps',                    'default': '-1.', 'description': ''},
-                           {'name': 'color_fps',                    'default': '-1.', 'description': ''},
-                           {'name': 'gyro_fps',                     'default': '-1.', 'description': ''},
-                           {'name': 'accel_fps',                    'default': '-1.', 'description': ''},
-                           {'name': 'color_qos',                    'default': 'SYSTEM_DEFAULT', 'description': 'QoS profile name'},
-                           {'name': 'confidence_qos',               'default': 'SYSTEM_DEFAULT', 'description': 'QoS profile name'},
-                           {'name': 'depth_qos',                    'default': 'SYSTEM_DEFAULT', 'description': 'QoS profile name'},
-                           {'name': 'fisheye_qos',                  'default': 'SYSTEM_DEFAULT', 'description': 'QoS profile name'},
-                           {'name': 'infra_qos',                    'default': 'SYSTEM_DEFAULT', 'description': 'QoS profile name'},
-                           {'name': 'pointcloud_qos',               'default': 'SYSTEM_DEFAULT', 'description': 'QoS profile name'},
-                           {'name': 'enable_gyro',                  'default': 'false', 'description': ''},
-                           {'name': 'enable_accel',                 'default': 'false', 'description': ''},
-                           {'name': 'pointcloud_texture_stream',    'default': 'RS2_STREAM_COLOR', 'description': 'testure stream for pointcloud'},
-                           {'name': 'pointcloud_texture_index',     'default': '0', 'description': 'testure stream index for pointcloud'},
-                           {'name': 'enable_sync',                  'default': 'false', 'description': ''},
-                           {'name': 'align_depth',                  'default': 'false', 'description': ''},
-                           {'name': 'filters',                      'default': "''", 'description': ''},
-                           {'name': 'clip_distance',                'default': '-2.', 'description': ''},
-                           {'name': 'linear_accel_cov',             'default': '0.01', 'description': ''},
-                           {'name': 'initial_reset',                'default': 'false', 'description': ''},
-                           {'name': 'allow_no_texture_points',      'default': 'false', 'description': ''},
-                           {'name': 'ordered_pc',                   'default': 'false', 'description': ''},
-                           {'name': 'calib_odom_file',              'default': "''", 'description': "''"},
-                           {'name': 'topic_odom_in',                'default': "''", 'description': 'topic for T265 wheel odometry'},
-                           {'name': 'tf_publish_rate',              'default': '20.0', 'description': 'Rate of publishing static_tf'},
-                           {'name': 'diagnostics_period',           'default': '0.0', 'description': 'Rate of publishing diagnostics. 0=Disabled'},
-                           {'name': 'rosbag_filename',              'default': "''", 'description': 'A realsense bagfile to run from as a device'},
-                           {'name': 'temporal.holes_fill',          'default': '0', 'description': 'Persistency mode'},
-                           {'name': 'stereo_module.exposure.1',     'default': '7500', 'description': 'Initial value for hdr_merge filter'},
-                           {'name': 'stereo_module.gain.1',         'default': '16', 'description': 'Initial value for hdr_merge filter'},
-                           {'name': 'stereo_module.exposure.2',     'default': '1', 'description': 'Initial value for hdr_merge filter'},
-                           {'name': 'stereo_module.gain.2',         'default': '16', 'description': 'Initial value for hdr_merge filter'},
-                           {'name': 'wait_for_device_timeout',      'default': '-1.', 'description': 'Timeout for waiting for device to connect (Seconds)'},
-                           {'name': 'reconnect_timeout',            'default': '6.', 'description': 'Timeout(seconds) between consequtive reconnection attempts'},
-                           {'name': 'odom_frame_id', 'default': 'odom', 'description': 'set odom frame'},   
-                           {'name': 'pose_frame_id', 'default': 'base_footprint', 'description': 'set pose frame'},  
-                           {'name': 'publish_tf', 'default': 'true', 'description': 'publish tf'},                                                               
-                                                       
-                          ]
 
 def declare_configurable_parameters(parameters):
-    return [DeclareLaunchArgument(param['name'], default_value=param['default'], description=param['description']) for param in parameters]
+    return [
+        DeclareLaunchArgument(param['name'],
+                              default_value=param['default'],
+                              description=param['description'])
+        for param in parameters
+    ]
+
 
 def set_configurable_parameters(parameters):
-    return dict([(param['name'], LaunchConfiguration(param['name'])) for param in parameters])
+    return dict([(param['name'], LaunchConfiguration(param['name']))
+                 for param in parameters])
+
 
 def generate_launch_description():
-    log_level = 'info'
-    if (os.getenv('ROS_DISTRO') == "dashing") or (os.getenv('ROS_DISTRO') == "eloquent"):
-        return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
-            # Realsense
-            launch_ros.actions.Node(
-                condition=IfCondition(PythonExpression([LaunchConfiguration('config_file'), " == ''"])),
-                package='realsense2_camera',
-                node_namespace=LaunchConfiguration("camera_name"),
-                node_name=LaunchConfiguration("camera_name"),
-                node_executable='realsense2_camera_node',
-                prefix=['stdbuf -o L'],
-                parameters=[set_configurable_parameters(configurable_parameters)
-                            ],
-                output='screen',
-                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+    if (os.getenv('ROS_DISTRO') == "dashing") or (os.getenv('ROS_DISTRO')
+                                                  == "eloquent"):
+        return LaunchDescription(
+            declare_configurable_parameters(configurable_parameters) + [
+                # Realsense
+                launch_ros.actions.Node(
+                    condition=IfCondition(
+                        PythonExpression(
+                            [LaunchConfiguration('config_file'), " == ''"])),
+                    package='realsense2_camera',
+                    node_namespace=LaunchConfiguration("camera_name"),
+                    node_name=LaunchConfiguration("camera_name"),
+                    node_executable='realsense2_camera_node',
+                    prefix=['stdbuf -o L'],
+                    parameters=[
+                        set_configurable_parameters(configurable_parameters)
+                    ],
+                    output='screen',
+                    arguments=[
+                        '--ros-args', '--log-level',
+                        LaunchConfiguration('log_level')
+                    ],
                 ),
-            launch_ros.actions.Node(
-                condition=IfCondition(PythonExpression([LaunchConfiguration('config_file'), " != ''"])),
-                package='realsense2_camera',
-                node_namespace=LaunchConfiguration("camera_name"),
-                node_name=LaunchConfiguration("camera_name"),
-                node_executable='realsense2_camera_node',
-                prefix=['stdbuf -o L'],
-                parameters=[set_configurable_parameters(configurable_parameters)
-                            , PythonExpression([LaunchConfiguration("config_file")])
-                            ],
-                output='screen',
-                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+                launch_ros.actions.Node(
+                    condition=IfCondition(
+                        PythonExpression(
+                            [LaunchConfiguration('config_file'), " != ''"])),
+                    package='realsense2_camera',
+                    node_namespace=LaunchConfiguration("camera_name"),
+                    node_name=LaunchConfiguration("camera_name"),
+                    node_executable='realsense2_camera_node',
+                    prefix=['stdbuf -o L'],
+                    parameters=[
+                        set_configurable_parameters(configurable_parameters),
+                        PythonExpression([LaunchConfiguration("config_file")])
+                    ],
+                    output='screen',
+                    arguments=[
+                        '--ros-args', '--log-level',
+                        LaunchConfiguration('log_level')
+                    ],
                 ),
             ])
     else:
-        return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
-            # Realsense
-            launch_ros.actions.Node(
-                condition=IfCondition(PythonExpression([LaunchConfiguration('config_file'), " == ''"])),
-                package='realsense2_camera',
-                namespace=LaunchConfiguration("camera_name"),
-                name=LaunchConfiguration("camera_name"),
-                executable='realsense2_camera_node',
-                parameters=[set_configurable_parameters(configurable_parameters)
-                            ],
-                remappings=[
-                   ('/camera/odom/sample', '/mammoth/odom'),
-
-                ],                            
-                output='screen',
-                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
-                emulate_tty=True,
+        return LaunchDescription(
+            declare_configurable_parameters(configurable_parameters) + [
+                # Realsense
+                launch_ros.actions.Node(
+                    condition=IfCondition(
+                        PythonExpression(
+                            [LaunchConfiguration('config_file'), " == ''"])),
+                    package='realsense2_camera',
+                    namespace=LaunchConfiguration("camera_name"),
+                    name=LaunchConfiguration("camera_name"),
+                    executable='realsense2_camera_node',
+                    parameters=[
+                        set_configurable_parameters(configurable_parameters)
+                    ],
+                    remappings=[
+                        ('/camera/odom/sample', '/mammoth/odom'),
+                    ],
+                    output='screen',
+                    arguments=[
+                        '--ros-args', '--log-level',
+                        LaunchConfiguration('log_level')
+                    ],
+                    emulate_tty=True,
                 ),
-            launch_ros.actions.Node(
-                condition=IfCondition(PythonExpression([LaunchConfiguration('config_file'), " != ''"])),
-                package='realsense2_camera',
-                namespace=LaunchConfiguration("camera_name"),
-                name=LaunchConfiguration("camera_name"),
-                executable='realsense2_camera_node',
-                parameters=[set_configurable_parameters(configurable_parameters)
-                            , PythonExpression([LaunchConfiguration("config_file")])
-                            ],
-                remappings=[
-                   ('/camera/odom/sample', '/mammoth/odom'),
-
-                ],                             
-                output='screen',
-                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
-                emulate_tty=True,
+                launch_ros.actions.Node(
+                    condition=IfCondition(
+                        PythonExpression(
+                            [LaunchConfiguration('config_file'), " != ''"])),
+                    package='realsense2_camera',
+                    namespace=LaunchConfiguration("camera_name"),
+                    name=LaunchConfiguration("camera_name"),
+                    executable='realsense2_camera_node',
+                    parameters=[
+                        set_configurable_parameters(configurable_parameters),
+                        PythonExpression([LaunchConfiguration("config_file")])
+                    ],
+                    remappings=[
+                        ('/camera/odom/sample', '/mammoth/odom'),
+                    ],
+                    output='screen',
+                    arguments=[
+                        '--ros-args', '--log-level',
+                        LaunchConfiguration('log_level')
+                    ],
+                    emulate_tty=True,
                 ),
-        ])
+            ])

--- a/mammoth_snowplow/launch/include/realsense/rs_t265_launch.py
+++ b/mammoth_snowplow/launch/include/realsense/rs_t265_launch.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # DESCRIPTION #
 # ----------- #
 # Use this launch file to launch a t265 device.
@@ -22,34 +21,63 @@
 # The Parameters available for definition in the command line are described in rs_launch.configurable_parameters
 # For example: to disable fisheye sensors:
 # ros2 launch realsense2_camera rs_t265_launch.py enable_fisheye1:=false enable_fisheye2:=false
-
-
 """Launch realsense2_camera node."""
-import copy
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
+from launch.substitutions import ThisLaunchFileDir
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import sys
 import pathlib
+
 sys.path.append(str(pathlib.Path(__file__).parent.absolute()))
 import rs_launch
 
-local_parameters = [{'name': 'device_type', 'default': 't265', 'description': 'choose device by type'},
-                    {'name': 'enable_pose', 'default': 'true', 'description': 'enable pose stream'},
-                    {'name': 'enable_fisheye1',              'default': 'true', 'description': 'enable fisheye1 stream'},
-                    {'name': 'enable_fisheye2',              'default': 'true', 'description': 'enable fisheye2 stream'},  
-                    {'name': 'odom_frame_id', 'default': 'odom', 'description': 'set odom frame'},      
-                    {'name': 'pose_frame_id', 'default': 'base_footprint', 'description': 'set pose frame'},                                                         
-                    {'name': 'publish_tf', 'default': 'false', 'description': 'publish tf'},                                                          
-                   ]
+local_parameters = [
+    {
+        'name': 'device_type',
+        'default': 't265',
+        'description': 'choose device by type'
+    },
+    {
+        'name': 'enable_pose',
+        'default': 'true',
+        'description': 'enable pose stream'
+    },
+    {
+        'name': 'enable_fisheye1',
+        'default': 'true',
+        'description': 'enable fisheye1 stream'
+    },
+    {
+        'name': 'enable_fisheye2',
+        'default': 'true',
+        'description': 'enable fisheye2 stream'
+    },
+    {
+        'name': 'odom_frame_id',
+        'default': 'odom',
+        'description': 'set odom frame'
+    },
+    {
+        'name': 'pose_frame_id',
+        'default': 'base_footprint',
+        'description': 'set pose frame'
+    },
+    {
+        'name': 'publish_tf',
+        'default': 'false',
+        'description': 'publish tf'
+    },
+]
+
 
 def generate_launch_description():
     return LaunchDescription(
-        rs_launch.declare_configurable_parameters(local_parameters) + 
-        [
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rs_launch.py']),
-            launch_arguments=rs_launch.set_configurable_parameters(local_parameters).items(),
-        ),
-    ])
+        rs_launch.declare_configurable_parameters(local_parameters) + [
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    [ThisLaunchFileDir(), '/rs_launch.py']),
+                launch_arguments=rs_launch.set_configurable_parameters(
+                    local_parameters).items(),
+            ),
+        ])

--- a/mammoth_snowplow/launch/include/roboteq/roboteq.launch.py
+++ b/mammoth_snowplow/launch/include/roboteq/roboteq.launch.py
@@ -26,38 +26,36 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
+
 
 def generate_launch_description():
     # ROS packages
     pkg_mammoth_snowplow = get_package_share_directory('mammoth_snowplow')
 
     # Config
-    roboteq_config = os.path.join(pkg_mammoth_snowplow, 'config/roboteq', 'roboteq.yaml')
+    roboteq_config = os.path.join(pkg_mammoth_snowplow, 'config/roboteq',
+                                  'roboteq.yaml')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
 
     # Nodes
-    roboteq = Node(
-        package='isc_roboteq',
-        executable='isc_roboteq',
-        name='isc_roboteq',
-        output='screen',
-        parameters=[roboteq_config],
-        remappings =[
-            ('/cmd_vel', '/mammoth/cmd_vel'),
-        ]
-    )
+    roboteq = Node(package='isc_roboteq',
+                   executable='isc_roboteq',
+                   name='isc_roboteq',
+                   output='screen',
+                   parameters=[roboteq_config],
+                   remappings=[
+                       ('/cmd_vel', '/mammoth/cmd_vel'),
+                   ])
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='false',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='false',
                               description='Use simulation time if true'),
         # Nodes
         roboteq,

--- a/mammoth_snowplow/launch/include/rviz/rviz.launch.py
+++ b/mammoth_snowplow/launch/include/rviz/rviz.launch.py
@@ -26,32 +26,35 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
 from launch.conditions import IfCondition
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     # ROS packages
-    pkg_mammoth_description = get_package_share_directory('mammoth_description')
+    pkg_mammoth_description = get_package_share_directory(
+        'mammoth_description')
 
     # launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
     use_rviz = LaunchConfiguration('use_rviz', default='true')
 
     # Nodes
-    rviz = Node(
-        package='rviz2',
-        executable='rviz2',
-        arguments=['-d', os.path.join(pkg_mammoth_description, 'rviz', 'mammoth_gazebo.rviz')],
-        condition=IfCondition(use_rviz)
-    )
+    rviz = Node(package='rviz2',
+                executable='rviz2',
+                arguments=[
+                    '-d',
+                    os.path.join(pkg_mammoth_description, 'rviz',
+                                 'mammoth_gazebo.rviz')
+                ],
+                condition=IfCondition(use_rviz))
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_rviz', default_value='false',
+        DeclareLaunchArgument('use_rviz',
+                              default_value='false',
                               description='Use simulation time if true'),
 
         # Node

--- a/mammoth_snowplow/launch/include/state_publishers/state_publishers.launch.py
+++ b/mammoth_snowplow/launch/include/state_publishers/state_publishers.launch.py
@@ -26,12 +26,10 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
+
 
 def generate_robot_model(pkg_description):
     urdf_dir = os.path.join(pkg_description, 'urdf')
@@ -43,39 +41,37 @@ def generate_robot_model(pkg_description):
 
 def generate_launch_description():
     # ROS packages
-    pkg_mammoth_description = get_package_share_directory('mammoth_description')
-    pkg_mammoth_snowplow = get_package_share_directory('mammoth_snowplow')
+    pkg_mammoth_description = get_package_share_directory(
+        'mammoth_description')
+    get_package_share_directory('mammoth_snowplow')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     robot_desc, urdf_file = generate_robot_model(pkg_mammoth_description)
 
     # Nodes
-    robot_state_publisher = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        name='robot_state_publisher',
-        output='screen',
-        parameters=[{
-            'use_sim_time': use_sim_time,
-            'robot_description': robot_desc,
-        }]
-    )
+    robot_state_publisher = Node(package='robot_state_publisher',
+                                 executable='robot_state_publisher',
+                                 name='robot_state_publisher',
+                                 output='screen',
+                                 parameters=[{
+                                     'use_sim_time': use_sim_time,
+                                     'robot_description': robot_desc,
+                                 }])
 
-    joint_state_publisher = Node(
-        package='joint_state_publisher',
-        executable='joint_state_publisher',
-        name='joint_state_publisher',
-        output='screen',
-        parameters=[{
-            'use_sim_time': use_sim_time
-        }]
-    )
+    joint_state_publisher = Node(package='joint_state_publisher',
+                                 executable='joint_state_publisher',
+                                 name='joint_state_publisher',
+                                 output='screen',
+                                 parameters=[{
+                                     'use_sim_time': use_sim_time
+                                 }])
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='false',
-                              description='Use simulation clock if true'   ),         
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='false',
+                              description='Use simulation clock if true'),
         # Nodes
         robot_state_publisher,
         joint_state_publisher,

--- a/mammoth_snowplow/launch/include/velocity_inverter/velocity_inverter.launch.py
+++ b/mammoth_snowplow/launch/include/velocity_inverter/velocity_inverter.launch.py
@@ -20,39 +20,35 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
 
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     # ROS packages
-    pkg_mammoth_gazebo = get_package_share_directory('mammoth_gazebo')
+    get_package_share_directory('mammoth_gazebo')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
 
-    velocity_inverter = Node(
-        package='vel_processor',
-        executable='vel_processor',
-        name='vel_processor',
-        output='screen',
-        parameters=[{
-            'use_sim_time': use_sim_time
-        }]
-    )
+    velocity_inverter = Node(package='vel_processor',
+                             executable='vel_processor',
+                             name='vel_processor',
+                             output='screen',
+                             parameters=[{
+                                 'use_sim_time': use_sim_time
+                             }])
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='true',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='true',
                               description='Use simulation clock if true'),
 
         # Nodes

--- a/mammoth_snowplow/launch/include/waypoint_publisher/waypoint.launch.py
+++ b/mammoth_snowplow/launch/include/waypoint_publisher/waypoint.launch.py
@@ -1,4 +1,3 @@
-
 # MIT License
 #
 # Copyright (c) 2021 Intelligent Systems Club
@@ -38,31 +37,32 @@ def generate_launch_description():
     pkg_mammoth_snowplow = get_package_share_directory('mammoth_snowplow')
 
     # Config
-    waypoints = os.path.join(pkg_mammoth_snowplow, 'config/waypoints', 'single-I.csv')
+    waypoints = os.path.join(pkg_mammoth_snowplow, 'config/waypoints',
+                             'single-I.csv')
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     follow_waypoints = LaunchConfiguration('follow_waypoints', default='true')
 
     # Nodes
-    waypoint_publisher = Node(
-        package='waypoint',
-        executable='waypoint',
-        name='waypoint',
-        output='screen',
-	    parameters=[
-            {'filename': waypoints},
-            {'use_sim_time': use_sim_time}
-        ],
-	    condition=IfCondition(follow_waypoints)
-    )
+    waypoint_publisher = Node(package='waypoint',
+                              executable='waypoint',
+                              name='waypoint',
+                              output='screen',
+                              parameters=[{
+                                  'filename': waypoints
+                              }, {
+                                  'use_sim_time': use_sim_time
+                              }],
+                              condition=IfCondition(follow_waypoints))
 
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='false',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='false',
                               description='Use simulation time if true'),
-        DeclareLaunchArgument('follow_waypoints', default_value='true',
+        DeclareLaunchArgument('follow_waypoints',
+                              default_value='true',
                               description='Follow waypoints if true'),
         # Nodes
         waypoint_publisher,
     ])
-

--- a/mammoth_snowplow/launch/mammoth.launch.py
+++ b/mammoth_snowplow/launch/mammoth.launch.py
@@ -27,11 +27,10 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-from launch_ros.actions import Node
+
 
 def generate_launch_description():
     # ROS packages
@@ -39,141 +38,133 @@ def generate_launch_description():
     pkg_teleop_twist_joy = get_package_share_directory('teleop_twist_joy')
 
     # Config
-    joy_config = os.path.join(pkg_mammoth_snowplow, 'config/joystick', 'xbone.config.yaml')
+    joy_config = os.path.join(pkg_mammoth_snowplow, 'config/joystick',
+                              'xbone.config.yaml')
 
     # Launch arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     use_rviz = LaunchConfiguration('use_rviz', default='true')
     follow_waypoints = LaunchConfiguration('follow_waypoints', default='false')
-    
+
     # Nodes
     state_publishers = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/state_publishers/state_publishers.launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/state_publishers/state_publishers.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     joy_with_teleop_twist = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource(
-         os.path.join(pkg_teleop_twist_joy, 'launch', 'teleop-launch.py')
-      ),
-      launch_arguments={
-          'joy_config': 'xbox',
-          'joy_dev': '/dev/input/js0',
-          'config_filepath': joy_config
-      }.items(),
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_teleop_twist_joy, 'launch', 'teleop-launch.py')),
+        launch_arguments={
+            'joy_config': 'xbox',
+            'joy_dev': '/dev/input/js0',
+            'config_filepath': joy_config
+        }.items(),
     )
 
     roboteq = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/roboteq/roboteq.launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/roboteq/roboteq.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     velocity_inverter = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/velocity_inverter/velocity_inverter.launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/velocity_inverter/velocity_inverter.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
-    
+
     ouster_os1 = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/ouster_os1/os1.launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(), 
-    )   
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/ouster_os1/os1.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
+    )
 
     realsense = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/realsense/rs_t265_launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(),
-    )    
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/realsense/rs_t265_launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
+    )
 
     lidar_processor = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/lidar_processor/lidar_processor.launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/lidar_processor/lidar_processor.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     pointcloud_to_laserscan = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/pointcloud_to_laserscan/pointcloud_to_laserscan.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
     )
 
     navigation = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/navigation/navigation.launch.py']),
-         launch_arguments={
-            'use_sim_time': use_sim_time
-        }.items(),
-    ) 
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/navigation/navigation.launch.py'
+        ]),
+        launch_arguments={'use_sim_time': use_sim_time}.items(),
+    )
 
     rviz = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         pkg_mammoth_snowplow, 'launch'),
-         '/include/rviz/rviz.launch.py']),
-         launch_arguments={
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/rviz/rviz.launch.py'
+        ]),
+        launch_arguments={
             'use_rviz': use_rviz,
             'use_sim_time': use_sim_time
-         }.items(),
+        }.items(),
     )
 
     waypoint_publisher = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-          pkg_mammoth_snowplow, 'launch'),
-          '/include/waypoint_publisher/waypoint.launch.py']
-        ),
+        PythonLaunchDescriptionSource([
+            os.path.join(pkg_mammoth_snowplow, 'launch'),
+            '/include/waypoint_publisher/waypoint.launch.py'
+        ]),
         launch_arguments={
-        	'use_sim_time': use_sim_time,
-        	'follow_waypoints': follow_waypoints
+            'use_sim_time': use_sim_time,
+            'follow_waypoints': follow_waypoints
         }.items(),
     )
-    
+
     return LaunchDescription([
         # Launch Arguments
-        DeclareLaunchArgument('use_sim_time', default_value='false',
+        DeclareLaunchArgument('use_sim_time',
+                              default_value='false',
                               description='Use simulation clock if true'),
-
-        DeclareLaunchArgument('use_rviz', default_value='true',
+        DeclareLaunchArgument('use_rviz',
+                              default_value='true',
                               description='Open rviz if true'),
-
-        DeclareLaunchArgument('follow_waypoints', default_value='false',
+        DeclareLaunchArgument('follow_waypoints',
+                              default_value='false',
                               description='follow way points if true'),
-                              
+
         # Nodes
         state_publishers,
         joy_with_teleop_twist,
         roboteq,
         velocity_inverter,
         ouster_os1,
- 
         realsense,
         lidar_processor,
         pointcloud_to_laserscan,
         navigation,
-
         rviz,
         waypoint_publisher,
     ])

--- a/mammoth_snowplow/launch/test/joystick_teleop.launch.py
+++ b/mammoth_snowplow/launch/test/joystick_teleop.launch.py
@@ -31,27 +31,32 @@ import launch_ros.actions
 def generate_launch_description():
     joy_config = launch.substitutions.LaunchConfiguration('joy_config')
     joy_dev = launch.substitutions.LaunchConfiguration('joy_dev')
-    config_filepath = launch.substitutions.LaunchConfiguration('config_filepath')
+    config_filepath = launch.substitutions.LaunchConfiguration(
+        'config_filepath')
 
     return launch.LaunchDescription([
-        launch.actions.DeclareLaunchArgument('joy_config', default_value='ps3'),
-        launch.actions.DeclareLaunchArgument('joy_dev', default_value='/dev/input/js0'),
-        launch.actions.DeclareLaunchArgument('config_filepath', default_value=[
+        launch.actions.DeclareLaunchArgument('joy_config',
+                                             default_value='ps3'),
+        launch.actions.DeclareLaunchArgument('joy_dev',
+                                             default_value='/dev/input/js0'),
+        launch.actions.DeclareLaunchArgument(
+            'config_filepath',
+            default_value=[
                 launch.substitutions.TextSubstitution(text=os.path.join(
-                    get_package_share_directory('teleop_twist_joy'), 'config', '')
-                ),
-                joy_config, launch.substitutions.TextSubstitution(text='.config.yaml')
-            ]
-        ),
-
-        launch_ros.actions.Node(
-            package='joy', executable='joy_node', name='joy_node',
-            parameters=[{
-                'dev': joy_dev,
-                'deadzone': 0.3,
-                'autorepeat_rate': 20.0,
-            }]),
-        launch_ros.actions.Node(
-            package='teleop_twist_joy', executable='teleop_node',
-            name='teleop_twist_joy_node', parameters=[config_filepath]),
+                    get_package_share_directory('teleop_twist_joy'), 'config',
+                    '')), joy_config,
+                launch.substitutions.TextSubstitution(text='.config.yaml')
+            ]),
+        launch_ros.actions.Node(package='joy',
+                                executable='joy_node',
+                                name='joy_node',
+                                parameters=[{
+                                    'dev': joy_dev,
+                                    'deadzone': 0.3,
+                                    'autorepeat_rate': 20.0,
+                                }]),
+        launch_ros.actions.Node(package='teleop_twist_joy',
+                                executable='teleop_node',
+                                name='teleop_twist_joy_node',
+                                parameters=[config_filepath]),
     ])


### PR DESCRIPTION
This PR addresses #58 by adding a step to the CI that auto formats python files and auto-pushes any fixes it makes. This should allow us to avoid getting linter errors on the ros2 CI. 

Unfortunatly, I squashed all the Python fixes the bot made while testing into my commit while rebasing, so those changes are also included in this commit. These changes do allow the ros2 CI to pass, so they should be fine, but the changelog is a little messy.