### PR TITLE
slam toolbox loop closure change

### DIFF
--- a/mammoth_gazebo/config/slam/mapper_params_online_async.yaml
+++ b/mammoth_gazebo/config/slam/mapper_params_online_async.yaml
@@ -39,13 +39,13 @@ slam_toolbox:
     use_scan_barycenter: true
     minimum_travel_distance: 0.08
     minimum_travel_heading: 0.06
-    scan_buffer_size: 20
-    scan_buffer_maximum_scan_distance: 10.0
+    scan_buffer_size: 15
+    scan_buffer_maximum_scan_distance: 7.0
     link_match_minimum_response_fine: 0.1  
-    link_scan_maximum_distance: 3.0
-    loop_search_maximum_distance: 4.0
+    link_scan_maximum_distance: 2.0
+    loop_search_maximum_distance: 1.0
     do_loop_closing: true 
-    loop_match_minimum_chain_size: 20     
+    loop_match_minimum_chain_size: 20    
     loop_match_maximum_variance_coarse: 3.0  
     loop_match_minimum_response_coarse: 0.35    
     loop_match_minimum_response_fine: 0.45

--- a/mammoth_snowplow/config/slam/mapper_params_online_async.yaml
+++ b/mammoth_snowplow/config/slam/mapper_params_online_async.yaml
@@ -39,13 +39,13 @@ slam_toolbox:
     use_scan_barycenter: true
     minimum_travel_distance: 0.08
     minimum_travel_heading: 0.06
-    scan_buffer_size: 20
-    scan_buffer_maximum_scan_distance: 10.0
+    scan_buffer_size: 15
+    scan_buffer_maximum_scan_distance: 7.0
     link_match_minimum_response_fine: 0.1  
-    link_scan_maximum_distance: 3.0
-    loop_search_maximum_distance: 4.0
+    link_scan_maximum_distance: 2.0
+    loop_search_maximum_distance: 1.0
     do_loop_closing: true 
-    loop_match_minimum_chain_size: 20     
+    loop_match_minimum_chain_size: 20    
     loop_match_maximum_variance_coarse: 3.0  
     loop_match_minimum_response_coarse: 0.35    
     loop_match_minimum_response_fine: 0.45


### PR DESCRIPTION
During the return of yeti on the single I, the loop closure search parameter was set to about 4 meters, so that means when yeti is about half way on the return side, slam toolbox would register it as a loop closure and the map would merge and cause yeti to freak out. so I decreased the `loop_search_maximum_distance` to about 1 meter and decreased `link_scan_maximum_distance` to about 2 meters effectively solving the issue on the return.